### PR TITLE
[GIL-54] use embedded text for pages instead of OCR if present

### DIFF
--- a/giles-spring/src/main/webapp/WEB-INF/views/login.jsp
+++ b/giles-spring/src/main/webapp/WEB-INF/views/login.jsp
@@ -15,7 +15,7 @@ that are then accessible through Digilib. Metadata of uploaded images  managed w
 </p>
 
 <p>
-To use Giles, you need to log in with your GitHub account. Don't have one? You can create one <a href="http://github.com">here</a>.
+To use Giles, you need to log in with your Google+ account. Don't have one? You can create one <a target="_blank" href="https://plus.google.com/">here</a>.
 </p>
 
 


### PR DESCRIPTION
If there is embedded text in a PDF, Giles extracts that text for each
page rather than running tesseract.